### PR TITLE
Update regex for object link.

### DIFF
--- a/docs/source/external_sources/digital_collections.rst
+++ b/docs/source/external_sources/digital_collections.rst
@@ -397,4 +397,4 @@ Object (Item/Collection):
 
 .. code-block::
 
-	^(http(s):\/\/digital\.lib\.utk\.edu\/collections\/islandora\/object\/).*([0-9]|collections%3A.*|gsmrc%3A.*|arrowmont%3A.*)$
+	^(http(s):).*([0-9]|collections%3A.*|gsmrc%3A.*|arrowmont%3A.*|\/)$


### PR DESCRIPTION
I never updated the regex I'm using in these docs for the object link following Mike's emails this summer about rfta objects. It is already on production.
@markpbaggett 